### PR TITLE
[scons] fix linkerscript path override

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -133,7 +133,7 @@ def build(env):
 
     # Generate the env.BuildTarget tool
     linkerscript = env.get(":platform:cortex-m:linkerscript.override")
-    linkerscript = env.relcwdoutpath(linkerscript) if linkerscript \
+    linkerscript = "$BASEPATH/{}".format(linkerscript) if linkerscript \
                    else "$BASEPATH/modm/link/linkerscript.ld"
     env.substitutions = env.query("::device")
     env.substitutions.update({


### PR DESCRIPTION
with the previous line the search was outside the project repo:

scons: *** [path_to_project/build/.../target.elf] Explicit dependency `path_to_parent_of_project/gen/.../ld/linkerscript.ld' not found, needed by target `path_to_project/build/.../target.elf'.
