### PR TITLE
[rtc/stm32] enable calibration on more supported cores. See AN4759

### DIFF
--- a/src/modm/platform/rtc/stm32/module.lb
+++ b/src/modm/platform/rtc/stm32/module.lb
@@ -38,8 +38,8 @@ def build(env):
         "with_ssr": target.family not in ["f1", "f2", "l1"],
         # F2, L1 have a smaller PREDIV_S register field.
         "bits_prediv_s": 13 if target.family in ["f2", "l1"] else 15,
-        # H7 calibration via CALP and CALM in RTC_CALR
-        "with_calpm" : target.family in ["h7"],
+        # F2, L1 do not have smooth calibration via CALP and CALM in RTC_CALR
+        "with_calpm": target.family not in ["f2", "l1"],
     }
     env.template("rtc.hpp.in")
     env.template("rtc_impl.hpp.in")

--- a/src/modm/platform/rtc/stm32/rtc.hpp.in
+++ b/src/modm/platform/rtc/stm32/rtc.hpp.in
@@ -93,10 +93,13 @@ public:
 	static void
 	disable();
 
-%% if with_calpm 
+%% if with_calpm
+	/// Set RTC calibration registers from PPB value.
+	/// range -487100 PPB — 488500 PPB with 954 PPB resolution.
 	static bool
 	setCalibration(int32_t ppb);
 
+	/// Get RTC calibration converted to PPB.
 	static int32_t
 	getCalibration();
 %%endif

--- a/src/modm/platform/rtc/stm32/rtc_impl.hpp.in
+++ b/src/modm/platform/rtc/stm32/rtc_impl.hpp.in
@@ -13,8 +13,6 @@
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/processing/fiber.hpp>
 
-#include <modm/debug.hpp>
-
 // Fix the inconsistent naming in ST's register files
 #ifdef RTC_ICSR_INIT
 #define RTC_ICSR RTC->ICSR
@@ -296,8 +294,6 @@ Rtc::setCalibration(int32_t ppb)
 	RTC->CALR = cal;
 	lock();
 
-	modm::log::info.hex() << " CALR: " << cal << modm::endl;
-
 	return true;
 }
 
@@ -305,7 +301,6 @@ inline int32_t
 Rtc::getCalibration()
 {
 	const uint32_t calr = RTC->CALR;
-	modm::log::info.hex() << " CALR: " << calr << modm::endl;
 	int32_t ppb = (calr & RTC_CALR_CALP) ? 488500 : 0;
 	ppb -= static_cast<int32_t>(calr & 0x01FF) * 954;
 	return ppb;


### PR DESCRIPTION
according to AN4759 more stm32 cores support RTC calibration
