### PR TITLE
[lbuild] Added missing dependency to accessor interface

### DIFF
--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -17,6 +17,7 @@ class Accessor(Module):
         module.description = "Memory Accessors"
 
     def prepare(self, module, options):
+        module.depends(":platform:core")
         return True
 
     def build(self, env):


### PR DESCRIPTION
The IOstream depends on all available accessors (RAM and FLASH).
The Flash accessor, however, includes `modm/platform/core/flash_reader_impl.hpp`. This dependency is not registered in the lbuild file.

This was noticed when building for the platform `hosted-linux`. 