### PR TITLE
[aws/uart] Added static attribute to necessarily static function

### DIFF
--- a/ext/aws/uart_buffer_freertos.hpp
+++ b/ext/aws/uart_buffer_freertos.hpp
@@ -148,7 +148,7 @@ public:
 	static void
 	flushWriteBuffer() { while(not isWriteFinished()); }
 
-	bool
+	static bool
 	isWriteFinished() { return transmitBufferSize() == 0 and Hal::isTransmitRegisterEmpty(); }
 
 	static std::size_t


### PR DESCRIPTION
```cpp
	static void
	flushWriteBuffer() { while(not isWriteFinished()); }
```

function is static, needs check whether write is finished.
That information can and should be gotten `static`, but the corresponding function is missing the attribute.

Probably forgotten.
