### PR TITLE
[lbuild] use absolute paths to linkerscripts

### DIFF
--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -36,7 +36,7 @@ def build(env):
     env.outbasepath = "modm/link"
     env.copy("linkerscript.ld")
     env.collect(":build:linkflags", "-L{project_source_dir}",
-                "-T{}".format(env.relcwdoutpath("modm/link/linkerscript.ld")))
+                "-T{}".format(env.cwdoutpath("modm/link/linkerscript.ld")))
 
     env.substitutions = {
         "target": target.identifier,

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -422,7 +422,7 @@ def build(env):
                 "-Wl,--no-warn-rwx-segment", "-L{project_source_dir}")
     # Linkerscript
     linkerscript = env["linkerscript.override"]
-    env.collect(":build:linkflags", "-T{}".format(env.relcwdoutpath(
+    env.collect(":build:linkflags", "-T{}".format(env.cwdoutpath(
             linkerscript if linkerscript else "modm/link/linkerscript.ld")))
 
     # Compilation for FPU


### PR DESCRIPTION
If the `project.xml` lbuild description file is not at the same folder level as the `SConstruct`, the emitted relative paths for the linkerscripts are incorrect.

This PR emits absolute paths to avoid that.

Needs fix at https://github.com/modm-io/lbuild/issues/85 (https://github.com/modm-io/lbuild/pull/86)